### PR TITLE
Specify location of cacheable static assets instead of relying on file extensions

### DIFF
--- a/drupal-ha.vcl
+++ b/drupal-ha.vcl
@@ -103,8 +103,8 @@ sub vcl_recv {
     }
   }
 
-  # Always cache the following file types for all users.
-  if (req.url ~ "(?i)\.(png|gif|jpeg|jpg|ico|swf|css|js|html|htm)(\?[a-z0-9]+)?$") {
+  # Always cache static assets in /files and /themes
+  if (req.url ~ "^/sites/.*/(files|themes)/") {
     unset req.http.Cookie;
   }
 
@@ -157,8 +157,8 @@ sub vcl_hash {
 
 # Code determining what to do when serving items from the Apache servers.
 sub vcl_backend_response {
-  # Don't allow static files to set cookies.
-  if (bereq.url ~ "(?i)\.(png|gif|jpeg|jpg|ico|swf|css|js|html|htm)(\?[a-z0-9]+)?$") {
+  # Don't allow static assets in /files or /themes to set cookies
+  if (bereq.url ~ "^/sites/.*/(files|themes)/") {
     # beresp == Back-end response from the web server.
     unset beresp.http.set-cookie;
   }

--- a/drupal-ha.vcl
+++ b/drupal-ha.vcl
@@ -106,7 +106,7 @@ sub vcl_recv {
   # Strip cookies from static assets in /files, /libraries, and /themes.
   # These requests are automatically disqualified from being cached if there are
   # any cookies. Stripping the cookies increases the hit rate.
-  if (req.url ~ "^/sites/.*/(files|libraries|themes)/") {
+  if (req.url ~ "^(/sites/.*)?/(files|libraries|themes)/") {
     unset req.http.Cookie;
   }
 
@@ -160,7 +160,7 @@ sub vcl_hash {
 # Code determining what to do when serving items from the Apache servers.
 sub vcl_backend_response {
   # Don't allow static assets in /files, /libraries, or /themes to set cookies
-  if (bereq.url ~ "^/sites/.*/(files|libraries|themes)/") {
+  if (bereq.url ~ "^(/sites/.*)/(files|libraries|themes)/") {
     # beresp == Back-end response from the web server.
     unset beresp.http.set-cookie;
   }

--- a/drupal-ha.vcl
+++ b/drupal-ha.vcl
@@ -103,7 +103,9 @@ sub vcl_recv {
     }
   }
 
-  # Always cache static assets in /files, /libraries, and /themes
+  # Strip cookies from static assets in /files, /libraries, and /themes.
+  # These requests are automatically disqualified from being cached if there are
+  # any cookies. Stripping the cookies increases the hit rate.
   if (req.url ~ "^/sites/.*/(files|libraries|themes)/") {
     unset req.http.Cookie;
   }

--- a/drupal-ha.vcl
+++ b/drupal-ha.vcl
@@ -103,8 +103,8 @@ sub vcl_recv {
     }
   }
 
-  # Always cache static assets in /files and /themes
-  if (req.url ~ "^/sites/.*/(files|themes)/") {
+  # Always cache static assets in /files, /libraries, and /themes
+  if (req.url ~ "^/sites/.*/(files|libraries|themes)/") {
     unset req.http.Cookie;
   }
 
@@ -157,8 +157,8 @@ sub vcl_hash {
 
 # Code determining what to do when serving items from the Apache servers.
 sub vcl_backend_response {
-  # Don't allow static assets in /files or /themes to set cookies
-  if (bereq.url ~ "^/sites/.*/(files|themes)/") {
+  # Don't allow static assets in /files, /libraries, or /themes to set cookies
+  if (bereq.url ~ "^/sites/.*/(files|libraries|themes)/") {
     # beresp == Back-end response from the web server.
     unset beresp.http.set-cookie;
   }

--- a/drupal-ha.vcl
+++ b/drupal-ha.vcl
@@ -103,12 +103,16 @@ sub vcl_recv {
     }
   }
 
-  # Strip cookies from static assets in /files, /libraries, and /themes.
+  # Strip cookies from the following file types for all users.
   # These requests are automatically disqualified from being cached if there are
   # any cookies. Stripping the cookies increases the hit rate.
-  if (req.url ~ "^(/sites/.*)?/(files|libraries|themes)/") {
+  if (req.url ~ "(?i)\.(png|gif|jpeg|jpg|ico|swf|css|js|html|htm)(\?[a-z0-9]+)?$") {
     unset req.http.Cookie;
   }
+  # Alternatively, strip cookies from directories of static assets.
+  #if (req.url ~ "^(/sites/.*)?/(files|libraries|themes)/") {
+  #  unset req.http.Cookie;
+  #}
 
   # Remove all cookies that Drupal doesn't need to know about. ANY remaining
   # cookie will cause the request to pass-through to Apache. For the most part
@@ -159,11 +163,16 @@ sub vcl_hash {
 
 # Code determining what to do when serving items from the Apache servers.
 sub vcl_backend_response {
-  # Don't allow static assets in /files, /libraries, or /themes to set cookies
-  if (bereq.url ~ "^(/sites/.*)/(files|libraries|themes)/") {
-    # beresp == Back-end response from the web server.
+  # Don't allow these file types to set cookies.
+  # Prevent these file types from setting cookies to increase the hit rate.
+  # Setting a cookie automatically disqualifies an object from being cached.
+  if (bereq.url ~ "(?i)\.(png|gif|jpeg|jpg|ico|swf|css|js|html|htm)(\?[a-z0-9]+)?$") {
     unset beresp.http.set-cookie;
   }
+  # Alternatively, specifiy known paths that contain static assets.
+  #if (bereq.url ~ "^(/sites/.*)/(files|libraries|themes)/") {
+  #  unset beresp.http.set-cookie;
+  #}
 
   # Allow stale-while-revalidate for up to 6 hours
   if (beresp.grace <= 6h) {

--- a/drupal.vcl
+++ b/drupal.vcl
@@ -80,7 +80,9 @@ sub vcl_recv {
     }
   }
 
-  # Always cache static assets in /files, /libraries, and /themes
+  # Strip cookies from static assets in /files, /libraries, and /themes.
+  # These requests are automatically disqualified from being cached if there are
+  # any cookies. Stripping the cookies increases the hit rate.
   if (req.url ~ "^/sites/.*/(files|libraries|themes)/") {
     unset req.http.Cookie;
   }

--- a/drupal.vcl
+++ b/drupal.vcl
@@ -80,12 +80,16 @@ sub vcl_recv {
     }
   }
 
-  # Strip cookies from static assets in /files, /libraries, and /themes.
+  # Strip cookies from the following file types for all users.
   # These requests are automatically disqualified from being cached if there are
   # any cookies. Stripping the cookies increases the hit rate.
-  if (req.url ~ "^(/sites/.*)/(files|libraries|themes)/") {
+  if (req.url ~ "(?i)\.(png|gif|jpeg|jpg|ico|swf|css|js|html|htm)(\?[a-z0-9]+)?$") {
     unset req.http.Cookie;
   }
+  # Alternatively, strip cookies from directories of static assets.
+  #if (req.url ~ "^(/sites/.*)?/(files|libraries|themes)/") {
+  #  unset req.http.Cookie;
+  #}
 
   # Remove all cookies that Drupal doesn't need to know about. ANY remaining
   # cookie will cause the request to pass-through to Apache. For the most part
@@ -136,11 +140,16 @@ sub vcl_hash {
 
 # Code determining what to do when serving items from the Apache servers.
 sub vcl_backend_response {
-  # Don't allow static assets in /files, /libraries, or /themes to set cookies
-  if (bereq.url ~ "^(/sites/.*)/(files|libraries|themes)/") {
-    # beresp == Back-end response from the web server.
+  # Don't allow these file types to set cookies.
+  # Prevent these file types from setting cookies to increase the hit rate.
+  # Setting a cookie automatically disqualifies an object from being cached.
+  if (bereq.url ~ "(?i)\.(png|gif|jpeg|jpg|ico|swf|css|js|html|htm)(\?[a-z0-9]+)?$") {
     unset beresp.http.set-cookie;
   }
+  # Alternatively, specifiy known paths that contain static assets.
+  #if (bereq.url ~ "^(/sites/.*)/(files|libraries|themes)/") {
+  #  unset beresp.http.set-cookie;
+  #}
 
   # Allow stale-while-revalidate for up to 6 hours
   if (beresp.grace <= 6h) {

--- a/drupal.vcl
+++ b/drupal.vcl
@@ -80,8 +80,8 @@ sub vcl_recv {
     }
   }
 
-  # Always cache static assets in /files and /themes
-  if (req.url ~ "^/sites/.*/(files|themes)/") {
+  # Always cache static assets in /files, /libraries, and /themes
+  if (req.url ~ "^/sites/.*/(files|libraries|themes)/") {
     unset req.http.Cookie;
   }
 
@@ -134,8 +134,8 @@ sub vcl_hash {
 
 # Code determining what to do when serving items from the Apache servers.
 sub vcl_backend_response {
-  # Don't allow static assets in /files or /themes to set cookies
-  if (bereq.url ~ "^/sites/.*/(files|themes)/") {
+  # Don't allow static assets in /files, /libraries, or /themes to set cookies
+  if (bereq.url ~ "^/sites/.*/(files|libraries|themes)/") {
     # beresp == Back-end response from the web server.
     unset beresp.http.set-cookie;
   }

--- a/drupal.vcl
+++ b/drupal.vcl
@@ -80,8 +80,8 @@ sub vcl_recv {
     }
   }
 
-  # Always cache the following file types for all users.
-  if (req.url ~ "(?i)\.(png|gif|jpeg|jpg|ico|swf|css|js|html|htm)(\?[a-z0-9]+)?$") {
+  # Always cache static assets in /files and /themes
+  if (req.url ~ "^/sites/.*/(files|themes)/") {
     unset req.http.Cookie;
   }
 
@@ -134,8 +134,8 @@ sub vcl_hash {
 
 # Code determining what to do when serving items from the Apache servers.
 sub vcl_backend_response {
-  # Don't allow static files to set cookies.
-  if (bereq.url ~ "(?i)\.(png|gif|jpeg|jpg|ico|swf|css|js|html|htm)(\?[a-z0-9]+)?$") {
+  # Don't allow static assets in /files or /themes to set cookies
+  if (bereq.url ~ "^/sites/.*/(files|themes)/") {
     # beresp == Back-end response from the web server.
     unset beresp.http.set-cookie;
   }

--- a/drupal.vcl
+++ b/drupal.vcl
@@ -83,7 +83,7 @@ sub vcl_recv {
   # Strip cookies from static assets in /files, /libraries, and /themes.
   # These requests are automatically disqualified from being cached if there are
   # any cookies. Stripping the cookies increases the hit rate.
-  if (req.url ~ "^/sites/.*/(files|libraries|themes)/") {
+  if (req.url ~ "^(/sites/.*)/(files|libraries|themes)/") {
     unset req.http.Cookie;
   }
 
@@ -137,7 +137,7 @@ sub vcl_hash {
 # Code determining what to do when serving items from the Apache servers.
 sub vcl_backend_response {
   # Don't allow static assets in /files, /libraries, or /themes to set cookies
-  if (bereq.url ~ "^/sites/.*/(files|libraries|themes)/") {
+  if (bereq.url ~ "^(/sites/.*)/(files|libraries|themes)/") {
     # beresp == Back-end response from the web server.
     unset beresp.http.set-cookie;
   }


### PR DESCRIPTION
I think this is safer than relying on filename extensions for stripping cookies to force cache. Consider the following example:

Private files are enabled, and User A gets a dynamically generated file, like a pdf. Then User B goes to the same URL, and should get a pdf with different content, but it is cached because cookies are stripped. Drupal puts private files in /system/files, and the cacheability of those files should not be messed with.

With this new method, anything in /sites/_/files or /sites/_/themes is considered static and cacheable. There are possibly rare cases where there are static assets in other locations, but this should cover most common cases. It is safer, since it excludes private files from the list, and is more maintainable.
